### PR TITLE
build(deps): pin ESLint to v9 until Next.js supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # ESLint 10 (released 2026-02) is not yet supported by the Next.js lint
+      # stack: eslint-config-next still bundles eslint-plugin-react /
+      # eslint-plugin-import / eslint-plugin-jsx-a11y, which cap their ESLint
+      # peer dependency at ^9. Upgrading crashes `npm run lint` (ESLint 10
+      # removed context.getFilename() and other APIs those plugins rely on).
+      # Tracking: https://github.com/vercel/next.js/issues/91710
+      # Remove this ignore once a v10-compatible eslint-config-next ships.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` rule for **ESLint major-version bumps**, so it stops re-opening the unmergeable ESLint 10 PR (#257).

## Why

ESLint 10 (released 2026-02-07) is **not yet supported by the Next.js lint stack**. `eslint-config-next@16.2.9` (latest) bundles plugins that still cap their ESLint peer dependency at `^9`:

- `eslint-plugin-react` — no stable v10 release yet (the long pole)
- `eslint-plugin-import` — fix requires migrating to `eslint-plugin-import-x`
- `eslint-plugin-jsx-a11y` — caps at `^9`

ESLint 10 removed APIs these plugins rely on (`context.getFilename()`, legacy config, etc.), so upgrading **crashes `npm run lint`** with a cascade of errors (`ERR_MODULE_NOT_FOUND @eslint/js` → `getFilename is not a function` → `scopeManager.addGlobals is not a function`). Verified locally on Node 24.

Vercel's tracking issue ([vercel/next.js#91710](https://github.com/vercel/next.js/issues/91710)) is open with no committed timeline.

## Decision

Stay on **ESLint 9** (still supported; only one major behind, and held back solely by Next's own plugins). All other dependencies remain current. Remove this ignore rule once a v10-compatible `eslint-config-next` ships.

Closes the loop on #257 (being closed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)